### PR TITLE
fix: allow to import first wallet from xprv

### DIFF
--- a/lib/util/preferences.dart
+++ b/lib/util/preferences.dart
@@ -102,7 +102,7 @@ class ApiPreferences {
       final result = json.decode(selectedAddressesList);
       return result[walletId];
     } else {
-      return '';
+      return null;
     }
   }
 }


### PR DESCRIPTION
return `null` instead of `""` to be able to catch the null value with `??` operator