### PR TITLE
fix: Avoid navigation in to the current route

### DIFF
--- a/lib/widgets/layouts/dashboard_layout.dart
+++ b/lib/widgets/layouts/dashboard_layout.dart
@@ -178,13 +178,16 @@ class DashboardLayoutState extends State<DashboardLayout>
   }
 
   List<Widget> _navigationActions() {
+    String currentRoute = ModalRoute.of(context)!.settings.name!;
     return [
       MouseRegion(
           cursor: SystemMouseCursors.click,
           child: GestureDetector(
             child: Icon(FontAwesomeIcons.gear,
                 size: 30, color: getButtonColorByRoute(PreferencePage.route)),
-            onTap: () => _goToSettings(),
+            onTap: currentRoute != PreferencePage.route
+                ? () => _goToSettings()
+                : () {},
           )),
     ];
   }

--- a/lib/widgets/layouts/dashboard_layout.dart
+++ b/lib/widgets/layouts/dashboard_layout.dart
@@ -75,12 +75,15 @@ class DashboardLayoutState extends State<DashboardLayout>
   }
 
   Widget _buildDashboardActions() {
+    String currentRoute = ModalRoute.of(context)!.settings.name!;
     return Row(mainAxisAlignment: MainAxisAlignment.center, children: [
       PaddedButton(
         color: getButtonColorByRoute(CreateVttScreen.route),
         padding: EdgeInsets.all(0),
         text: 'Send',
-        onPressed: _showCreateVTTDialog,
+        onPressed: currentRoute != CreateVttScreen.route
+            ? _showCreateVTTDialog
+            : () {},
         icon: Icon(
           FontAwesomeIcons.paperPlane,
           size: 18,
@@ -91,8 +94,10 @@ class DashboardLayoutState extends State<DashboardLayout>
         color: getButtonColorByRoute(DashboardScreen.route),
         padding: EdgeInsets.all(0),
         text: 'Home',
-        onPressed: () =>
-            Navigator.pushReplacementNamed(context, DashboardScreen.route),
+        onPressed: currentRoute != DashboardScreen.route
+            ? () =>
+                Navigator.pushReplacementNamed(context, DashboardScreen.route)
+            : () {},
         icon: Icon(
           FontAwesomeIcons.wallet,
           size: 18,
@@ -103,7 +108,9 @@ class DashboardLayoutState extends State<DashboardLayout>
         color: getButtonColorByRoute(ReceiveTransactionScreen.route),
         padding: EdgeInsets.all(0),
         text: 'Receive',
-        onPressed: _showReceiveDialog,
+        onPressed: currentRoute != ReceiveTransactionScreen.route
+            ? _showReceiveDialog
+            : () {},
         icon: Transform.rotate(
             angle: 90 * math.pi / 90,
             child: Icon(


### PR DESCRIPTION
a fix is to get the currentRoute and and check if it matches what which route the button represents. if it is a match -> pass an empty function, if it is not -> trigger the navigation