### PR TITLE
Fix: Error on Pending TX

### DIFF
--- a/lib/bloc/explorer/explorer_bloc.dart
+++ b/lib/bloc/explorer/explorer_bloc.dart
@@ -152,10 +152,13 @@ class ExplorerBloc extends Bloc<ExplorerEvent, ExplorerState> {
     }
     for (int i = 0; i < unconfirmedVtts.length; i++) {
       ValueTransferInfo _vtt = unconfirmedVtts[i];
-      ValueTransferInfo vtt =
-          await Locator.instance.get<ApiExplorer>().getVtt(_vtt.txnHash);
-      if (_vtt.status != vtt.status) {
-        await database.updateVtt(wallet.id, vtt);
+      try{
+        ValueTransferInfo vtt =
+        await Locator.instance.get<ApiExplorer>().getVtt(_vtt.txnHash);
+        if (_vtt.status != vtt.status) {
+          await database.updateVtt(wallet.id, vtt);
+        }
+      } catch(e){
       }
     }
     emit(ExplorerState.synced(database.walletStorage));


### PR DESCRIPTION
For unconfirmed transactions, the `getVtt` method returns a `ValueTransferInfo`  for mined / confirmed txns or a `HashInfo` if the transaction is still pending. wrapping it in a try catch block removes the error.